### PR TITLE
Don't redirect to login if page does not exist

### DIFF
--- a/includes/classes/class-ct-db-registration.php
+++ b/includes/classes/class-ct-db-registration.php
@@ -1014,8 +1014,21 @@ if( ! class_exists( 'CT_DB_Registration' ) ) { // Don't initialise if there's al
 			}
 
 			// If we're heading towards wp-login.php and our settings are right
-			if( 'wp-login.php' == $pagenow && isset( $options['hide_wp_login'] ) && isset( $options['frontend_login_page'] ) ) {
-				$redirect_url = esc_url_raw( add_query_arg( 'login', 'bounced', get_permalink( $options['frontend_login_page'] ) ) );
+			if ( 'wp-login.php' === $pagenow && ! empty( $options['hide_wp_login'] ) && ! empty( $options['frontend_login_page'] ) ) {
+				$frontend_login_page = $options['frontend_login_page'];
+
+				if ( 'publish' !== get_post_status( $frontend_login_page ) ) {
+					return;
+				}
+
+				$redirect_url = get_permalink( $frontend_login_page );
+
+				// Check that the redirect URL is a valid page.
+				if ( empty( $redirect_url ) ) {
+					return;
+				}
+
+				$redirect_url = esc_url_raw( add_query_arg( 'login', 'bounced', $redirect_url ) );
 				wp_redirect( $redirect_url );
 				exit;
 			}


### PR DESCRIPTION
If a login page does not exist, don't redirect from WP Admin to the old deleted/draft page

### Description of the Change

This code introduces a check to make sure that the custom login page exists before it tries to redirect to it. If it does not exist, it will use the WP Admin login.

### Benefits

Avoids users getting locked out of their site if they delete the login page

### Changelog Entry

- Fix: Don't redirect to the login page if it does not exist

Fixes: #52 