### PR TITLE
If a cron is running, load the settings

### DIFF
--- a/wp-discussion-board.php
+++ b/wp-discussion-board.php
@@ -25,7 +25,7 @@ if ( ! defined( 'WPDBD_PLUGIN_FILE' ) ) {
 // Load config files.
 require_once 'includes/config/config.php';
 
-if ( is_admin() ) {
+if ( is_admin() || wp_doing_cron() ) {
 	require_once 'includes/config/settings.php';
 }
 


### PR DESCRIPTION
### Description of the Change

When a cron is running, we need to load the settings so that crons do not throw errors.

### Changelog Entry

Fix: Load settings when a cron is running

Fixes #50 